### PR TITLE
#12 Fix markdown backticks becomming syntax highlighted

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -7,7 +7,7 @@ import 'highlight.js/styles/github.css';
 
 const highlight = (instance) => {
   const domNode = ReactDOM.findDOMNode(instance);
-  const nodes = domNode.querySelectorAll('code');
+  const nodes = domNode.querySelectorAll('pre code');
 
   if (nodes.length > 0) {
     for (var i = 0; i < nodes.length; i=i+1) {


### PR DESCRIPTION
Seems like the selector for `pre code` was changed to just `code` in this commit: https://github.com/tuchk4/storybook-readme/commit/60dba5a7960d1c4002b509bf28b85c08f4e50204#diff-600386b6077350650f252d685cbe2565L48

This PR reverts that.