### PR TITLE
add facade as main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,4 @@ node_modules
 npm-debug.log
 /coverage
 /components
-/constants.js
-/readme-manager.js
-/register.js
-/with-readme.js
-/with-docs.js
+/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,9 @@ node_modules
 npm-debug.log
 /coverage
 /components
-/*.js
+/constants.js
+/readme-manager.js
+/register.js
+/with-readme.js
+/with-docs.js
+/index.js

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ It is possible to combine *withDocs* and *withReadme* - [Example combined APIs](
 
 ```js
 import ButtonReadme from '../components/button/README.md';
-import withReadme from 'storybook-readme/with-readme';
-import withDocs from 'storybook-readme/with-docs';
+import { withReadme, withDocs } from 'storybook-readme';
 
 storiesOf('Button', module)
   .add('Default', withReadme(ButtonReadme, () => <Button onClick={action('clicked')} label="Hello Button"/>))
@@ -81,7 +80,7 @@ storiesOf('Content', module)
 
 **withReadme** example:
 ```js
-import withReadme from 'storybook-readme/with-readme';
+import { withReadme } from 'storybook-readme';
 import OriginalButtonREADME from 'node_modules/components/button/README.md';
 import ButtonREADME from '../components/components/button/README.md';
 
@@ -94,7 +93,7 @@ storiesOf('Button', module)
 
 **withDocs** example:
 ```js
-import withDocs from 'storybook-readme/with-docs';
+import { withDocs } from 'storybook-readme';
 import ButtonREADME from '../components/components/button/README.md';
 
 storiesOf('Button', module)
@@ -115,7 +114,7 @@ In this way code of stories is more clean.
 
 **withReadme** example:
 ```js
-import withReadme from 'storybook-readme/with-readme';
+import { withReadme } from 'storybook-readme';
 import OriginalButtonREADME from 'node_modules/components/button/README.md';
 import ButtonREADME from '../components/components/button/README.md';
 
@@ -129,7 +128,7 @@ storiesOf('Button', module)
 
 **withDocs** example:
 ```js
-import withDocs from 'storybook-readme/with-docs';
+import { withDocs } from 'storybook-readme';
 import ButtonREADME from 'node_modules/component/README.md';
 
 storiesOf('Button', module)
@@ -149,7 +148,7 @@ Will appear at all stories that uses `withDocs` api.
 > Note: Should be added before all stories initialization.
 
 ```js
-import withDocs from 'storybook-readme/with-docs';
+import { withDocs } from 'storybook-readme';
 import DocsFooterReadme from 'components/DOCS_FOOTER.md';
 
 withDocs.addFooter(DocsFooterReadme);

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { storiesOf, action, linkTo } from '@storybook/react';
 import { withKnobs, text, boolean, number } from '@storybook/addon-knobs';
-import withReadme from '../../src/with-readme';
-import withDocs from '../../src/with-docs';
+import { withReadme, withDocs } from '../../src';
 
 import Button from '../components/Button';
 import Content from '../components/Content';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "storybook-readme",
   "version": "3.1.0-beta2",
   "description": "React storybook addon to show components README",
+  "main": "index.js",
   "homepage": "https://github.com/tuchk4/storybook-readme",
   "bugs": "https://github.com/tuchk4/storybook-readme/issues",
   "repository": {
@@ -13,12 +14,8 @@
     "string-raw": "^1.0.1"
   },
   "files": [
-    "components",
-    "constants.js",
-    "readme-manager.js",
-    "register.js",
-    "with-readme.js",
-    "with-docs.js"
+    "/components",
+    "/*.js"
   ],
   "devDependencies": {
     "@storybook/addon-info": "^3.2.12",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,13 @@
     "string-raw": "^1.0.1"
   },
   "files": [
-    "/components",
-    "/*.js"
+    "components",
+    "constants.js",
+    "readme-manager.js",
+    "register.js",
+    "with-readme.js",
+    "with-docs.js",
+    "index.js"
   ],
   "devDependencies": {
     "@storybook/addon-info": "^3.2.12",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export { default as withReadme } from './with-readme';
+export { default as withDocs } from './with-docs';


### PR DESCRIPTION
## Add main file pointing to facade

Change usage from
```js
import withReadme from 'storybook-readme/with-readme';
import withDocs from 'storybook-readme/with-docs';
```
to
```js
import { withReadme, withDocs } from 'storybook-readme';
```

#### NB
This is non-breaking -- using the old imports will still work