### PR TITLE
Remove h-scroll on README panel

### DIFF
--- a/packages/storybook-readme/src/components/ReadmePanel.js
+++ b/packages/storybook-readme/src/components/ReadmePanel.js
@@ -42,6 +42,8 @@ export default class ReadmePanel extends React.Component {
 
     const el = ReactDOM.findDOMNode(this);
 
+    el.parentNode.style.minWidth = '0';
+
     highlight(el, {
       withJSX: true,
     });
@@ -74,7 +76,9 @@ export default class ReadmePanel extends React.Component {
   }
 
   render() {
-    const { docs: { docsAfterPreview, docsBeforePreview } } = this.state;
+    const {
+      docs: { docsAfterPreview, docsBeforePreview },
+    } = this.state;
 
     if (!docsAfterPreview && !docsBeforePreview) {
       return (
@@ -87,7 +91,7 @@ export default class ReadmePanel extends React.Component {
     }
 
     return (
-      <div style={{ padding: '10px' }}>
+      <div style={{ padding: '10px', minWidth: '0' }}>
         {docsBeforePreview &&
           docsBeforePreview.map((doc, index) => (
             <div


### PR DESCRIPTION
## Issue

When viewing text in the README panel, wide items like `<pre>` elements and tables can easily push the width of the document wider than the panel, making it difficult to read.

## Proposed Solution

A common fix for this issue (which manifests specifically in flex layouts) is to add `min-width: 0;` to the flex container. For this PR, I'm adding it to the `markdown-body` wrapper element, _as well as the panel container_, via `el.parentNode`. 

I know adjusting the style of the container _outside_ this component is bad practice. But:

- It achieves the purpose easily
- Making the same change "properly" will either mean an inscrutable PR to `storybook`, or to `storybook/addons` providing the ability to style panel containers - high lift for a small change
- If something goes wrong (such as the flex structure of storybook changing upstream) the worst case here is likely to be a simple reversion to previous behavior. 

In short, I think doing this is low risk and reasonable, and makes a big difference to the UX.

---

## Screenshots

### Before - see the second paragraph is cut off:
![screen shot 2018-05-22 at 11 32 05 am](https://user-images.githubusercontent.com/248669/40373215-68de2ede-5db4-11e8-93ce-6f0160026b7c.png)

### After - see the code container now scrolls instead of the whole body:
![screen shot 2018-05-22 at 11 32 16 am](https://user-images.githubusercontent.com/248669/40373237-73e70d3c-5db4-11e8-8d23-d7647012ff0f.png)
