### PR TITLE
Fix crash when story splitting is not used

### DIFF
--- a/packages/storybook-readme/src/index.js
+++ b/packages/storybook-readme/src/index.js
@@ -53,8 +53,8 @@ function withCallType({ type, config }) {
       const normalizedDocs = normalizeDocs(args);
       return handler.doc({
         docs: [
-          ...normalizedDocs.docsBeforePreview,
-          ...normalizedDocs.docsAfterPreview,
+          ...(normalizedDocs.docsBeforePreview || []),
+          ...(normalizedDocs.docsAfterPreview || []),
         ],
         config,
       });


### PR DESCRIPTION
99f8fe1 introduced a crash when the `<!-- STORY -->` split is not used. `normalizeDocs` will return an object where `docsBeforePreview` is either null or an array of one or more items, and the change to `withCallType` will try to spread `null` into the array. When this runs through the babel-generated `_toConsumableArray` function, it will crash on `Array.from(null)`

```
Cannot convert undefined or null to object
    TypeError: Cannot convert undefined or null to object
    at Function.from (<anonymous>)
    at _toConsumableArray (http://localhost:6007/vendors~main.0a2989a2c5963538da99.bundle.js:1:35667)
    at http://localhost:6007/vendors~main.0a2989a2c5963538da99.bundle.js:1:36555
    at exports.doc (http://localhost:6007/vendors~main.0a2989a2c5963538da99.bundle.js:1:38187)
    at Module.<anonymous> (http://localhost:6007/main.0a2989a2c5963538da99.bundle.js:1:866)
    at Module.1001 (http://localhost:6007/main.0a2989a2c5963538da99.bundle.js:1:920)
    at __webpack_require__ (http://localhost:6007/runtime~main.0a2989a2c5963538da99.bundle.js:1:1238)
    at webpackContext (http://localhost:6007/main.0a2989a2c5963538da99.bundle.js:1:321210)
    at http://localhost:6007/main.0a2989a2c5963538da99.bundle.js:1:315843
    at Array.forEach (<anonymous>)
```