### PR TITLE
Fix styling not inherited with Marked component

### DIFF
--- a/packages/storybook-readme/src/components/Marked.js
+++ b/packages/storybook-readme/src/components/Marked.js
@@ -4,6 +4,7 @@ import marked from 'marked';
 
 import highlight from '../services/highlite';
 import transformEmojis from '../services/transformEmojis';
+import '../styles/github-markdown-css';
 
 export default class Marked extends React.Component {
   ref = null;


### PR DESCRIPTION
Hi! I had the same problem as #114 when it is used alone.
It is fixed by adding the missing styles in the Marked component.