### PR TITLE
add support to hide some parts of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ configureReadme({
 
 - `<!-- STORY -->` placeholder for story
 - `<!-- PROPS -->` placeholder for props table
+- `<!-- STORY HIDE START -->`, `<!-- STORY HIDE END -->` content enclosed by the tags won't be shown in stories
 
 ```md
 Button variants could be imported separately.
@@ -294,6 +295,10 @@ Button variants could be imported separately.
 Example:
 
 <!-- STORY -->
+
+<!-- STORY HIDE START -->
+content here won't be shown in stories
+<!-- STORY HIDE END -->
 
 Some docs after story
 ```

--- a/packages/example-react/components/Button/README.md
+++ b/packages/example-react/components/Button/README.md
@@ -8,6 +8,12 @@ import Button from 'components/Button';
 
 <!-- STORY -->
 
+<!-- STORY HIDE START -->
+
+The content here won't be shown in stories.
+
+<!-- STORY HIDE END -->
+
 #### Icons
 
 ```js

--- a/packages/storybook-readme/src/const.js
+++ b/packages/storybook-readme/src/const.js
@@ -2,6 +2,7 @@ export const CHANNEL_SET_SIDEBAR_DOCS = 'SET_SIDEPAGE_DOCS';
 
 export const MARKER_STORY = '<!-- STORY -->';
 export const MARKER_PROPS_TABLE = '<!-- PROPS -->';
+export const MARKER_HIDDEN = /<!-- STORY HIDE START -->(.|\s)*?<!-- STORY HIDE END -->/g;
 
 export const LAYOUT_TYPE_MD = 'MD';
 export const LAYOUT_TYPE_FOOTER_MD = 'FOOTER_MD';

--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -10,6 +10,7 @@ import {
   LAYOUT_TYPE_STORY,
   LAYOUT_TYPE_HEADER_MD,
   LAYOUT_TYPE_FOOTER_MD,
+  MARKER_HIDDEN,
 } from '../const';
 
 function split(md, story) {
@@ -43,7 +44,7 @@ function split(md, story) {
 }
 
 function processMd(md) {
-  return marked(transformEmojis(md));
+  return marked(transformEmojis(md.replace(MARKER_HIDDEN, '')));
 }
 
 export default function getDocsLayout({ md, story }) {


### PR DESCRIPTION
Hi, I add a new feature to prevent some parts of readme show in stories.
This is useful to me because I want to put a link to storybook pages in Readme, but I don't want the link shows in storybook pages.

syntax:
```
// Readme.md
<!-- STORY HIDE START -->
The content here won't show in stories.
<!-- STORY HIDE END -->
```