### PR TITLE
Fix ESM modules - fixes support Jest/Storyshots

### DIFF
--- a/packages/storybook-readme/.babelrc
+++ b/packages/storybook-readme/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["react-app", { "absoluteRuntime": false }]],
+  "presets": [["react-app", { "absoluteRuntime": false, "useESModules": false }]],
   "plugins": ["@babel/plugin-transform-modules-commonjs"]
 }


### PR DESCRIPTION
The babel preset `react-app` offers a setting `useESModules` to disable ESM modules inside babel runtime. Disabling ESM fixes Jest as it assumes that all 3rd party dependencies from `node_modules` are defined as commonjs.