### PR TITLE
Update propsTable rendering for react-typescript-docgen-loader@3.1.0 & multiline descriptions

### DIFF
--- a/packages/storybook-readme/src/services/getPropsTables/index.js
+++ b/packages/storybook-readme/src/services/getPropsTables/index.js
@@ -11,14 +11,30 @@ const getMarkdown = ({ type, name }) => {
   }
 
   let md = `### ${name} Props\n`;
-  md += '|Name|Required|Type|DefaultValue|Description|\n';
-  md += '|---|---|---|---|---|\n';
+  /* copy & modified from addon-info */
+  md += `<table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Required</th>
+        <th>Type</th>
+        <th>DefaultValue</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>`;
 
   propDefinitions.forEach(prop => {
-    md += `|${prop.property}|${prop.required ? '+' : '-'}|${prop.propType}|${
-      prop.defaultValue ? prop.defaultValue : ''
-    }|${prop.description || '-'}\n`;
-  });
+    md += `<tr>
+      <td>${prop.property}</td>
+      <td>${prop.required ? '+' : '-'}</td>
+      <td>${prop.propType}</td>
+      <td>${prop.defaultValue ? prop.defaultValue : ''}</td>
+      <td>${prop.description || '-'}</td>
+    </tr>`
+  })
+  
+  md += '</tbody></table>';
 
   return marked(md);
 };

--- a/packages/storybook-readme/src/services/getPropsTables/parseProps.js
+++ b/packages/storybook-readme/src/services/getPropsTables/parseProps.js
@@ -21,7 +21,7 @@ const propsFromDocgen = type => {
   Object.keys(docgenInfoProps).forEach(property => {
     const docgenInfoProp = docgenInfoProps[property];
     const defaultValueDesc = docgenInfoProp.defaultValue || {};
-    const propType = docgenInfoProp.flowType || docgenInfoProp.type || 'other';
+    const propType = docgenInfoProp.flowType || (typeof docgenInfoProp.type === "object" ? docgenInfoProp.type.name : docgenInfoProp.type) || 'other';
 
     props[property] = {
       property,


### PR DESCRIPTION
Fixes #137 

- Updates propType name extraction from Object if available (react-typescript-docgen-loader v3.1.0)
- Update propTable rendering with HTML `<table>` to allow multiline rendering in desciptions and correct rendering of union-types separated by `|`