### PR TITLE
Add filtering prop table docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Will be applied for series of stories.
       codeTheme: 'github',
 
       /**
+       * You can include prop tables locally here. See `propTables` example
+       * for more information
+       */
+      includePropTables: [YourImportedReactComponent],
+
+      /**
        * Wrapper for story. Usually used to set some styles
        * NOTE: will be applied only for content docs (docs around the story)
        *
@@ -302,6 +308,10 @@ addParameters({
   readme: {
     // You can set a code theme globally.
     codeTheme: 'github',
+
+    // You can exclude prop tables globally here. See `propTables` example
+    // for more information
+    excludePropTables: [YourImportedReactComponent]
   },
 });
 ```

--- a/packages/example-react/components/PropTables/RenderPropComponent.js
+++ b/packages/example-react/components/PropTables/RenderPropComponent.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export class RenderPropComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleMouseMove = this.handleMouseMove.bind(this);
+    this.state = { x: 0, y: 0 };
+  }
+
+  handleMouseMove(event) {
+    this.setState({
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }
+
+  render() {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          width: '100%',
+          height: '100%',
+          border: this.props.border,
+        }}
+        onMouseMove={this.handleMouseMove}
+      >
+        {this.props.children(this.state)}
+      </div>
+    );
+  }
+}
+
+RenderPropComponent.defaultProps = {
+  type: 'RenderProp Component',
+  border: '1px solid red',
+};
+
+RenderPropComponent.propTypes = {
+  /**
+   * This is a Render Prop Component!
+   */
+  type: PropTypes.string.isRequired,
+
+  /**
+   * Border value
+   */
+  border: PropTypes.string.isRequired,
+};
+
+export const DisplayMouseCoordinates = ({ name, x, y }) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        border: '1px solid black',
+        width: '500px',
+        height: '500px',
+      }}
+    >
+      <div>{name}</div>
+      <span>{`x: ${x}, y: ${y}`}</span>
+    </div>
+  );
+};
+
+DisplayMouseCoordinates.defaultProps = {
+  name: 'DisplayMouseCoordinates Component',
+};
+
+DisplayMouseCoordinates.propTypes = {
+  /**
+   * Name of the component
+   */
+  name: PropTypes.string.isRequired,
+  /**
+   * Name of the component
+   */
+  x: PropTypes.number,
+  /**
+   * Name of the component
+   */
+  y: PropTypes.number,
+};

--- a/packages/example-react/components/PropTables/SmallComponentOne.js
+++ b/packages/example-react/components/PropTables/SmallComponentOne.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const SmallComponentOne = ({ type }) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        border: '1px solid black',
+        width: '200px',
+        height: '50px',
+      }}
+    >
+      {type}
+    </div>
+  );
+};
+
+SmallComponentOne.defaultProps = {
+  type: 'Small Component One',
+};
+
+SmallComponentOne.propTypes = {
+  /**
+   * Type of the component(small one)
+   */
+  type: PropTypes.string.isRequired,
+};

--- a/packages/example-react/components/PropTables/SmallComponentThree.js
+++ b/packages/example-react/components/PropTables/SmallComponentThree.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const SmallComponentThree = ({ type, backgroundColor }) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        border: '1px solid black',
+        width: '200px',
+        height: '50px',
+        backgroundColor,
+      }}
+    >
+      {type}
+    </div>
+  );
+};
+
+SmallComponentThree.defaultProps = {
+  type: 'Small Component Three',
+  backgroundColor: 'black',
+};
+
+SmallComponentThree.propTypes = {
+  /**
+   * Type of the component(small three)
+   */
+  type: PropTypes.string.isRequired,
+
+  /**
+   * Background color of the component
+   */
+  backgroundColor: PropTypes.string.isRequired,
+};

--- a/packages/example-react/components/PropTables/SmallComponentTwo.js
+++ b/packages/example-react/components/PropTables/SmallComponentTwo.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const SmallComponentTwo = ({ type, color }) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        border: '1px solid black',
+        width: '200px',
+        height: '50px',
+        color,
+      }}
+    >
+      {type}
+    </div>
+  );
+};
+
+SmallComponentTwo.defaultProps = {
+  type: 'Small Component Two',
+  color: 'blue',
+};
+
+SmallComponentTwo.propTypes = {
+  /**
+   * Type of the component(small two)
+   */
+  type: PropTypes.string.isRequired,
+
+  /**
+   * Color of the component
+   */
+  color: PropTypes.string.isRequired,
+};

--- a/packages/example-react/components/PropTables/WrapperComponent.js
+++ b/packages/example-react/components/PropTables/WrapperComponent.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const WrapperComponent = ({ width, height, children }) => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        border: '2px solid black',
+        width,
+        height,
+        justifyContent: 'space-evenly',
+        alignItems: 'center',
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+WrapperComponent.defaultProps = {
+  width: '200px',
+  height: '200px',
+};
+
+WrapperComponent.propTypes = {
+  /**
+   * Width of the component
+   */
+  width: PropTypes.string.isRequired,
+
+  /**
+   * Height of the component
+   */
+  height: PropTypes.string.isRequired,
+
+  /**
+   * Children's are needed
+   */
+  children: PropTypes.node,
+};

--- a/packages/example-react/components/PropTables/withHOC.js
+++ b/packages/example-react/components/PropTables/withHOC.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const withHOC = options => WrappedComponent => {
+  const Enhanced = props => {
+    return <WrappedComponent {...props} />;
+  };
+  Enhanced.defaultProps = {
+    name: 'Enhanced Component',
+    whatever: 'Whatever string here',
+  };
+  Enhanced.propTypes = {
+    /**
+     * Name of this Component
+     */
+    name: PropTypes.string.isRequired,
+
+    /**
+     * Whatever string here
+     */
+    whatever: PropTypes.string.isRequired,
+  };
+
+  return Enhanced;
+};

--- a/packages/example-react/stories/withPropsTable/basic.js
+++ b/packages/example-react/stories/withPropsTable/basic.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import ButtonWithPropTypes from '../../components/Button/ButtonWithPropTypes';
+
+const Basic = `
+# Basic Usage
+
+If your React component is already using \`PropTypes\`, then It is easy to
+show it in a table format by adding \`<!-- PROPS -->\` to \`readme\` object's
+\`content\`.
+
+### From specific story
+\`\`\`javascript
+import ButtonWithPropTypes from '../../components/Button/ButtonWithPropTypes';
+storiesOf('Your story name', module).add(
+  'Your story name',
+  () => <ButtonWithPropTypes label={'Hello Im Button with propTypes'} />,
+  {
+    readme: {
+      content: \`<!-- STORY --><!-- PROPS -->\`,
+    }
+  }
+);
+\`\`\`
+
+You can notice from below that the React component is showing and \`PropTypes\`
+that you specified to component is showing as a table format.
+`;
+
+storiesOf('PropsTable', module).add(
+  'Basic Usage',
+  () => <ButtonWithPropTypes label={'Hello Im Button with propTypes'} />,
+  {
+    readme: {
+      content: `${Basic}<!-- STORY --><!-- PROPS -->`,
+
+      // This is not necessary in normal situation. The reason for
+      // `includePropTables` is needed here is because `ButtonWithPropTypes` is
+      // specified in `excludePropTables` at `config.js`
+      includePropTables: [ButtonWithPropTypes],
+    },
+  }
+);

--- a/packages/example-react/stories/withPropsTable/hocPattern.js
+++ b/packages/example-react/stories/withPropsTable/hocPattern.js
@@ -28,7 +28,7 @@ export const withHOC = options => WrappedComponent => {
 \`\`\`
 `;
 
-const Multiple = `
+const HocPattern = `
 # HOC Pattern
 
 Currently using HOC pattern in actual usage is very limited. It will show the
@@ -87,7 +87,7 @@ storiesOf('PropsTable|More usages', module).add(
   ),
   {
     readme: {
-      content: `${Multiple}<!-- STORY --><!-- PROPS -->`,
+      content: `${HocPattern}<!-- STORY --><!-- PROPS -->`,
     },
   }
 );

--- a/packages/example-react/stories/withPropsTable/hocPattern.js
+++ b/packages/example-react/stories/withPropsTable/hocPattern.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+const SeeHOCComponent = `
+\`\`\`javascript
+export const withHOC = options => WrappedComponent => {
+  const Enhanced = props => {
+    return <WrappedComponent {...props} />;
+  };
+  Enhanced.defaultProps = {
+    name: 'Enhanced Component',
+    whatever: 'Whatever string here',
+  };
+  Enhanced.propTypes = {
+    /**
+     * Name of this Component
+     */
+    name: PropTypes.string.isRequired,
+
+    /**
+     * Whatever string here
+     */
+    whatever: PropTypes.string.isRequired,
+  };
+
+  return Enhanced;
+};
+\`\`\`
+`;
+
+const Multiple = `
+# HOC Pattern
+
+Currently using HOC pattern in actual usage is very limited. It will show the
+tables of \`Enhancing Component\`with its prop names, but \`Type\` is always 
+\`other\` and \`Description\` is always blank. It is due to the limitation of
+\`react-docgen\`. Please see the related.
+issues.
+[#288](https://github.com/reactjs/react-docgen/issues/288), 
+[#336](https://github.com/reactjs/react-docgen/issues/336), 
+
+### From specific story
+\`\`\`javascript
+import { SmallComponentThree } from '../../components/PropTables/SmallComponentThree';
+import { withHOC } from '../../components/PropTables/withHOC';
+const EnhancedSmallComponent = withHOC({ maybe: 'some option' })(
+  SmallComponentThree
+);
+storiesOf('PropsTable|More usages', module).add(
+  'HOC pattern',
+  () => (
+    <EnhancedSmallComponent
+      backgroundColor="lightgrey"
+      type="I'm an Enhanced Small Component"
+    />
+  ),
+  {
+    readme: {
+      content: \`<!-- STORY --><!-- PROPS -->\`,
+    },
+  }
+);
+\`\`\`
+
+You can notice from below that propTable of \`Enhancing Component\` inside of
+HOC component is only showing.
+
+**Note**: Only \`Enhancing Component\` propTable is showing.
+<details>
+  <summary>See HOC Component and Enhancing Component inside of it</summary>
+  ${SeeHOCComponent}
+</details>
+`;
+
+import { SmallComponentThree } from '../../components/PropTables/SmallComponentThree';
+import { withHOC } from '../../components/PropTables/withHOC';
+const EnhancedSmallComponent = withHOC({ maybe: 'some option' })(
+  SmallComponentThree
+);
+storiesOf('PropsTable|More usages', module).add(
+  'HOC pattern',
+  () => (
+    <EnhancedSmallComponent
+      backgroundColor="lightgrey"
+      type="I'm an Enhanced Small Component"
+    />
+  ),
+  {
+    readme: {
+      content: `${Multiple}<!-- STORY --><!-- PROPS -->`,
+    },
+  }
+);

--- a/packages/example-react/stories/withPropsTable/includeLocally.js
+++ b/packages/example-react/stories/withPropsTable/includeLocally.js
@@ -40,6 +40,11 @@ inside of \`excludePropTables\`. This is because the implementation of
 this is to give the user an excluding feature globally for conveninece, 
 however whenever user wants, they can include whatever component they want
 and ignore global \`excludePropTables\` rule.
+
+**Note**: \`includePropTables\` doesn't add propTable to its showing list.
+It shows that are **already** inside of list which is rendered from 
+story. Currently you can't add whatever propTable that are not rendered
+from story.
 `;
 
 storiesOf('PropsTable', module).add(

--- a/packages/example-react/stories/withPropsTable/index.js
+++ b/packages/example-react/stories/withPropsTable/index.js
@@ -1,2 +1,3 @@
+import './basic';
 import './excludeGlobally';
 import './includeLocally';

--- a/packages/example-react/stories/withPropsTable/index.js
+++ b/packages/example-react/stories/withPropsTable/index.js
@@ -1,5 +1,6 @@
 import './basic';
 import './multipleComponents';
 import './hocPattern';
+import './renderPropPattern';
 import './excludeGlobally';
 import './includeLocally';

--- a/packages/example-react/stories/withPropsTable/index.js
+++ b/packages/example-react/stories/withPropsTable/index.js
@@ -1,3 +1,4 @@
 import './basic';
+import './multipleComponents';
 import './excludeGlobally';
 import './includeLocally';

--- a/packages/example-react/stories/withPropsTable/index.js
+++ b/packages/example-react/stories/withPropsTable/index.js
@@ -1,4 +1,5 @@
 import './basic';
 import './multipleComponents';
+import './hocPattern';
 import './excludeGlobally';
 import './includeLocally';

--- a/packages/example-react/stories/withPropsTable/multipleComponents.js
+++ b/packages/example-react/stories/withPropsTable/multipleComponents.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+const SeeWrapperComponent = `
+\`\`\`javascript
+export const WrapperComponent = ({ width, height, children }) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        border: "2px solid black",
+        width,
+        height,
+        justifyContent: "space-evenly",
+        alignItems: "center"
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+\`\`\`
+`;
+
+const Multiple = `
+# Multiple Components
+
+PropTables of multiple components can be shown at the same time. It will show all the 
+propTables, so \`excludePropTables, includePropTables\` feature can be useful if you
+want to constrain what to be shown.
+
+### From specific story
+\`\`\`javascript
+import { WrapperComponent } from "../../components/PropTables/WrapperComponent";
+import { SmallComponentOne } from "../../components/PropTables/SmallComponentOne";
+import { SmallComponentTwo } from "../../components/PropTables/SmallComponentTwo";
+import { SmallComponentThree } from "../../components/PropTables/SmallComponentThree";
+storiesOf('Your story name', module).add(
+  'Your story name',
+  () => (
+    <WrapperComponent width="300px" height="200px">
+      <SmallComponentOne type="I'm First!" />
+      <SmallComponentTwo type="I'm Second!" color="orange" />
+      <SmallComponentThree type="I'm Third!" backgroundColor="lightgrey" />
+    </WrapperComponent>
+  ),
+  {
+    readme: {
+      content: \`<!-- STORY --><!-- PROPS -->\`,
+    }
+  }
+);
+\`\`\`
+
+You can notice from below that 4 components and its propTabels are showing.
+
+**Caveat**: Component using \`{this.props.children}\` is still showing all its
+children's propTables(\`WrapperComponent\` in this example)
+<details>
+  <summary>See WrapperComponent</summary>
+  ${SeeWrapperComponent}
+</details>
+`;
+
+import { WrapperComponent } from '../../components/PropTables/WrapperComponent';
+import { SmallComponentOne } from '../../components/PropTables/SmallComponentOne';
+import { SmallComponentTwo } from '../../components/PropTables/SmallComponentTwo';
+import { SmallComponentThree } from '../../components/PropTables/SmallComponentThree';
+storiesOf('PropsTable|More usages', module).add(
+  'Multiple components',
+  () => (
+    <WrapperComponent width="300px" height="200px">
+      <SmallComponentOne type="I'm First!" />
+      <SmallComponentTwo type="I'm Second!" color="orange" />
+      <SmallComponentThree type="I'm Third!" backgroundColor="lightgrey" />
+    </WrapperComponent>
+  ),
+  {
+    readme: {
+      content: `${Multiple}<!-- STORY --><!-- PROPS -->`,
+    },
+  }
+);

--- a/packages/example-react/stories/withPropsTable/renderPropPattern.js
+++ b/packages/example-react/stories/withPropsTable/renderPropPattern.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+const RenderPropPattern = `
+# RenderProp Pattern
+
+Currently using RenderProp pattern in actual usage is very limited. 
+It will only show the propTable of \`RenderProp Component\`. PropTable of
+actual component that is used inside of renderProp is not showing.
+
+### From specific story
+\`\`\`javascript
+import {
+  RenderPropComponent,
+  DisplayMouseCoordinates,
+} from '../../components/PropTables/RenderPropComponent';
+storiesOf('PropsTable|More usages', module).add(
+  'RenderProp pattern',
+  () => (
+    <RenderPropComponent border='2px solid purple'>
+      {mouse => (
+        <DisplayMouseCoordinates
+          name="I'm a DisplayMouseCoordinates Component!"
+          x={mouse.x}
+          y={mouse.y}
+        />
+      )}
+    </RenderPropComponent>
+  ),
+  {
+    readme: {
+      content: \`<!-- STORY --><!-- PROPS -->\`,
+    },
+  }
+);
+\`\`\`
+
+You can notice from below that propTable of \`RenderProp Component\`
+is only showing. (No propTable of \`DisplayMouseCoordinates\`)
+
+**Note**: Only \`RenderProp Component\` propTable is showing. No 
+children components.
+`;
+
+import {
+  RenderPropComponent,
+  DisplayMouseCoordinates,
+} from '../../components/PropTables/RenderPropComponent';
+
+storiesOf('PropsTable|More usages', module).add(
+  'RenderProp pattern',
+  () => (
+    <RenderPropComponent border="2px solid purple">
+      {mouse => (
+        <DisplayMouseCoordinates
+          name="I'm a DisplayMouseCoordinates Component!"
+          x={mouse.x}
+          y={mouse.y}
+        />
+      )}
+    </RenderPropComponent>
+  ),
+  {
+    readme: {
+      content: `${RenderPropPattern}<!-- STORY --><!-- PROPS -->`,
+    },
+  }
+);


### PR DESCRIPTION
Hi, It is a follow up of #163. I added more examples and it usages or behaviours on propTables. 
I found that this `propTable` feature is little bit tricky because of how `react-docgen` or `prop-types` works.
Hopefully this looks fine(please let me know if anything should be changed)

