### PR TITLE
Set default values for excludePropTables/includePropTables parameters

### DIFF
--- a/packages/storybook-readme/src/vue/index.js
+++ b/packages/storybook-readme/src/vue/index.js
@@ -62,6 +62,8 @@ export const addReadme = makeDecorator({
               footer: parameters.footer || '',
               header: parameters.header || '',
               md: parameters.content || '',
+              excludePropTables: parameters.excludePropTables || [],
+              includePropTables: parameters.includePropTables || [],
               story,
             });
 
@@ -70,6 +72,8 @@ export const addReadme = makeDecorator({
         if (parameters.sidebar) {
           const sidebarLayout = getDocsLayout({
             md: parameters.sidebar,
+            excludePropTables: parameters.excludePropTables || [],
+            includePropTables: parameters.includePropTables || [],
             story,
           });
 


### PR DESCRIPTION
Resolves #183 by setting defaulting excludePropTables and includePropTables to empty arrays. Only an issue in for vue as react version does this already.