### PR TITLE
Fix filteringPropTable warnings from getDocsLayout

### DIFF
--- a/packages/storybook-readme/src/html/index.js
+++ b/packages/storybook-readme/src/html/index.js
@@ -16,6 +16,8 @@ export const addReadme = makeDecorator({
           footer: parameters.footer || '',
           header: parameters.header || '',
           md: parameters.content || '',
+          excludePropTables: parameters.excludePropTables || [],
+          includePropTables: parameters.includePropTables || [],
           story,
         });
 
@@ -26,6 +28,8 @@ export const addReadme = makeDecorator({
         footer: parameters.footer || '',
         header: parameters.header || '',
         md: parameters.sidebar,
+        excludePropTables: parameters.excludePropTables || [],
+        includePropTables: parameters.includePropTables || [],
         story,
       });
 

--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -61,8 +61,8 @@ function processMd(md) {
 export default function getDocsLayout({
   md,
   story,
-  excludePropTables,
-  includePropTables,
+  excludePropTables = [],
+  includePropTables = [],
 }) {
   const mdAsArray = Array.isArray(md) ? [...md] : [md];
   // const mdWithEmojis = mdAsArray.map(md => transformEmojis(md));


### PR DESCRIPTION
Follow up of #184 (closes #179 too)

This will resolve the same issue on `html` part and potential mistakes in the future when other frameworks are added.