### PR TITLE
feat: story source placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Will be applied for series of stories.
       StoryPreview: ({ children}) => <div>{children}</div>
 
       /**
-       * Wrapper for hedaer docs. Usually used to set some styles
+       * Wrapper for header docs. Usually used to set some styles
        * NOTE: will be applied only for content docs (docs around the story)
        *
        * React: React.ReactNode
@@ -288,7 +288,7 @@ configureReadme({
   ),
 
   /**
-   * Wrapper for hedaer docs. Usually used to set some styles
+   * Wrapper for header docs. Usually used to set some styles
    * React: React.ReactNode
    * Vue: Vue component
    */
@@ -329,6 +329,7 @@ addParameters({
 ## Readme placeholders
 
 - `<!-- STORY -->` placeholder for story
+- `<!-- STORY_SOURCE -->` placeholder for story source
 - `<!-- PROPS -->` placeholder for props table. There are some issue with props parsing. Clarification [issue#137](https://github.com/tuchk4/storybook-readme/issues/137#issuecomment-481307652)
 - `<!-- STORY HIDE START -->`, `<!-- STORY HIDE END -->` content enclosed by the tags won't be shown in stories
 

--- a/packages/example-react/components/Button/README.md
+++ b/packages/example-react/components/Button/README.md
@@ -10,6 +10,10 @@ import Button from 'components/Button';
 
 <!-- STORY -->
 
+#### Story Source
+
+<!-- SOURCE -->
+
 <!-- STORY HIDE START -->
 
 The content here won't be shown in stories.

--- a/packages/storybook-readme/package.json
+++ b/packages/storybook-readme/package.json
@@ -21,6 +21,7 @@
     "node-emoji": "1.10.0",
     "prism-themes": "^1.1.0",
     "prismjs": "^1.16.0",
+    "react-element-to-jsx-string": "^14.0.2",
     "string-raw": "^1.0.1",
     "vuex": "^3.1.0"
   },

--- a/packages/storybook-readme/src/components/ReadmeContent/index.js
+++ b/packages/storybook-readme/src/components/ReadmeContent/index.js
@@ -13,6 +13,7 @@ import insertCodeThemeCss from '../../styles/codeThemeCss';
 import {
   LAYOUT_TYPE_MD,
   LAYOUT_TYPE_STORY,
+  LAYOUT_TYPE_STORY_SOURCE,
   LAYOUT_TYPE_PROPS_TABLE,
   LAYOUT_TYPE_FOOTER_MD,
   LAYOUT_TYPE_HEADER_MD,
@@ -27,6 +28,7 @@ export default class ReadmeContent extends React.Component {
     types: [
       LAYOUT_TYPE_MD,
       LAYOUT_TYPE_STORY,
+      LAYOUT_TYPE_STORY_SOURCE,
       LAYOUT_TYPE_PROPS_TABLE,
       LAYOUT_TYPE_FOOTER_MD,
       LAYOUT_TYPE_HEADER_MD,
@@ -145,6 +147,17 @@ export default class ReadmeContent extends React.Component {
                 } else {
                   return <StoryPreview key={index}>{content}</StoryPreview>;
                 }
+              }
+
+              case LAYOUT_TYPE_STORY_SOURCE: {
+                return (
+                  <DocPreview key={index}>
+                    <div
+                      className={'markdown-body'}
+                      dangerouslySetInnerHTML={{ __html: content }}
+                    />
+                  </DocPreview>
+                );
               }
 
               case LAYOUT_TYPE_PROPS_TABLE: {

--- a/packages/storybook-readme/src/const.js
+++ b/packages/storybook-readme/src/const.js
@@ -1,6 +1,7 @@
 export const CHANNEL_SET_SIDEBAR_DOCS = 'SET_SIDEPAGE_DOCS';
 
 export const MARKER_STORY = '<!-- STORY -->';
+export const MARKER_STORY_SOURCE = '<!-- SOURCE -->';
 export const MARKER_PROPS_TABLE = '<!-- PROPS -->';
 export const MARKER_HIDDEN = /<!-- STORY HIDE START -->(.|\s)*?<!-- STORY HIDE END -->/g;
 
@@ -8,4 +9,5 @@ export const LAYOUT_TYPE_MD = 'MD';
 export const LAYOUT_TYPE_FOOTER_MD = 'FOOTER_MD';
 export const LAYOUT_TYPE_HEADER_MD = 'HEADER_MD';
 export const LAYOUT_TYPE_STORY = 'STORY';
+export const LAYOUT_TYPE_STORY_SOURCE = 'STORY_SOURCE';
 export const LAYOUT_TYPE_PROPS_TABLE = 'PROPS';

--- a/packages/storybook-readme/src/index.js
+++ b/packages/storybook-readme/src/index.js
@@ -17,7 +17,7 @@ export const configureReadme = parameters => {
 
   config.addStoryPreview(parameters.StoryPreview);
   config.addDocPreview(parameters.DocPreview);
-  config.addHedaerPreview(parameters.HeaderPreview);
+  config.addHeaderPreview(parameters.HeaderPreview);
   config.addFooterPreview(parameters.FooterPreview);
 };
 

--- a/packages/storybook-readme/src/services/config.js
+++ b/packages/storybook-readme/src/services/config.js
@@ -14,7 +14,7 @@ export function addStoryPreview(Preview) {
 export function addDocPreview(Preview) {
   config.DocPreview = Preview;
 }
-export function addHedaerPreview(Preview) {
+export function addHeaderPreview(Preview) {
   config.HeaderPreview = Preview;
 }
 export function addFooterPreview(Preview) {

--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -43,7 +43,7 @@ function split(md, story, config) {
 
             return {
               type: LAYOUT_TYPE_STORY_SOURCE,
-              content: processMd('```jsx\n ' + source + ' \n```'),
+              content: processMd('```jsx\n' + source + '\n```'),
             };
 
           case LAYOUT_TYPE_PROPS_TABLE:

--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -72,9 +72,12 @@ function getStorySource(
     maxInlineAttributesLineLength: 100,
   }
 ) {
-  const source = story ? jsxToString(story.props.children, options) : '';
+  const storySource = story && story.props && story.props.children;
+  const stringifiedSource = storySource
+    ? jsxToString(storySource, options)
+    : '';
 
-  return processMd('```jsx\n' + source + '\n```');
+  return processMd('```jsx\n' + stringifiedSource + '\n```');
 }
 
 function processMd(md) {

--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -39,11 +39,9 @@ function split(md, story, config) {
             };
 
           case LAYOUT_TYPE_STORY_SOURCE:
-            const source = story ? jsxToString(story.props.children) : '';
-
             return {
               type: LAYOUT_TYPE_STORY_SOURCE,
-              content: processMd('```jsx\n' + source + '\n```'),
+              content: getStorySource(story),
             };
 
           case LAYOUT_TYPE_PROPS_TABLE:
@@ -64,6 +62,19 @@ function split(md, story, config) {
         }
       })
   );
+}
+
+function getStorySource(
+  story,
+  options = {
+    tabStop: 2,
+    sortProps: true,
+    maxInlineAttributesLineLength: 100,
+  }
+) {
+  const source = story ? jsxToString(story.props.children, options) : '';
+
+  return processMd('```jsx\n' + source + '\n```');
 }
 
 function processMd(md) {

--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -3,15 +3,18 @@ import marked from './marked';
 import getPropsTables from './getPropsTables';
 import { validatePropTables } from './getPropsTables/validatePropTables';
 import { getConfig } from './config';
+import jsxToString from 'react-element-to-jsx-string';
 
 import {
   LAYOUT_TYPE_MD,
   LAYOUT_TYPE_PROPS_TABLE,
   LAYOUT_TYPE_STORY,
+  LAYOUT_TYPE_STORY_SOURCE,
   LAYOUT_TYPE_HEADER_MD,
   LAYOUT_TYPE_FOOTER_MD,
   MARKER_HIDDEN,
   MARKER_STORY,
+  MARKER_STORY_SOURCE,
   MARKER_PROPS_TABLE,
 } from '../const';
 
@@ -22,6 +25,7 @@ function split(md, story, config) {
        * Should replace <!-- --> with custom placeholders to allow default md/html comments
        */
       .replace(MARKER_STORY, `___{{${LAYOUT_TYPE_STORY}}}___`)
+      .replace(MARKER_STORY_SOURCE, `___{{${LAYOUT_TYPE_STORY_SOURCE}}}___`)
       .replace(MARKER_PROPS_TABLE, `___{{${LAYOUT_TYPE_PROPS_TABLE}}}___`)
       .split(/___{{|}}___/)
       // .split(/<!--|-->/)
@@ -32,6 +36,14 @@ function split(md, story, config) {
             return {
               type: LAYOUT_TYPE_STORY,
               content: story,
+            };
+
+          case LAYOUT_TYPE_STORY_SOURCE:
+            const source = story ? jsxToString(story.props.children) : '';
+
+            return {
+              type: LAYOUT_TYPE_STORY_SOURCE,
+              content: processMd('```jsx\n ' + source + ' \n```'),
             };
 
           case LAYOUT_TYPE_PROPS_TABLE:

--- a/packages/storybook-readme/src/vue/index.js
+++ b/packages/storybook-readme/src/vue/index.js
@@ -15,7 +15,7 @@ export const configureReadme = parameters => {
 
   config.addStoryPreview(parameters.StoryPreview);
   config.addDocPreview(parameters.DocPreview);
-  config.addHedaerPreview(parameters.HeaderPreview);
+  config.addHeaderPreview(parameters.HeaderPreview);
   config.addFooterPreview(parameters.FooterPreview);
 };
 


### PR DESCRIPTION
Adds `<!-- SOURCE -->` placeholder.

Example:

![image](https://user-images.githubusercontent.com/2752665/60613738-1df62480-9d91-11e9-9dcc-6f550fa24907.png)


TODO:
- [ ] Update Tests
- [x] Figure out what to do with formatting
- [ ] Should we expose formatting options as config?


@tuchk4 / @lonyele Not sure if this is the right approach 🤷‍♀ 

Closes: https://github.com/tuchk4/storybook-readme/issues/187