### PR TITLE
Fix default codeTheme

### DIFF
--- a/packages/storybook-readme/src/index.js
+++ b/packages/storybook-readme/src/index.js
@@ -34,7 +34,7 @@ export const addReadme = makeDecorator({
   parameterName: 'readme',
   wrapper: (getStory, context) => {
     const parameters = getParameters(context);
-
+    const codeTheme = parameters.codeTheme || 'github';
     const story = <React.Fragment>{getStory(context)}</React.Fragment>;
     const layout = parameters.layout
       ? parameters.layout
@@ -62,7 +62,7 @@ export const addReadme = makeDecorator({
       channel.emit(CHANNEL_SET_SIDEBAR_DOCS, {
         layout: sidebarLayout,
         theme: parameters.theme,
-        codeTheme: parameters.highlightSidebar ? parameters.codeTheme : null,
+        codeTheme: parameters.highlightSidebar ? codeTheme : null,
       });
     }
 
@@ -70,7 +70,7 @@ export const addReadme = makeDecorator({
       <ReadmeContent
         layout={layout}
         theme={parameters.theme}
-        codeTheme={parameters.highlightContent ? parameters.codeTheme : null}
+        codeTheme={parameters.highlightContent ? codeTheme : null}
         StoryPreview={parameters.StoryPreview}
         HeaderPreview={parameters.HeaderPreview}
         DocPreview={parameters.DocPreview}


### PR DESCRIPTION
Fixes #186 

## What I did
Make default value of `codeTheme` to `'github` when there is no input from the user. I moved the default `codeTheme` logic from `insertCodeThemeCss({})` to `<ReadmeContent />` so that It doesn't break newly added `highlightContent` and `highlightSidebar` features.

## More Info
While the feature requested from #173 was [implemented](https://github.com/tuchk4/storybook-readme/commit/176242837437750e565300fd131cbe6fe9f8697e#diff-9d34cd04c930175e76f630ee5c964ea4L76), it was removed accidentally.