### PR TITLE
Fix unnecessary styling by removing it

### DIFF
--- a/packages/storybook-readme/src/components/Preview/StoryPreview.js
+++ b/packages/storybook-readme/src/components/Preview/StoryPreview.js
@@ -2,12 +2,14 @@ import React from 'react';
 
 export default props => (
   <div
-    style={{
-      // display: 'flex',
-      // alignItems: 'center',
-      // justifyContent: 'center',
-      margin: '32px 0',
-    }}
+    style={
+      {
+        // display: 'flex',
+        // alignItems: 'center',
+        // justifyContent: 'center',
+        // margin: '32px 0',
+      }
+    }
   >
     <div>{props.children}</div>
   </div>

--- a/packages/storybook-readme/src/vue/components/Preview/StoryPreview.js
+++ b/packages/storybook-readme/src/vue/components/Preview/StoryPreview.js
@@ -5,7 +5,7 @@ export default {
         // display: 'flex',
         // alignItems: 'center',
         // justifyContent: 'center',
-        margin: '32px 0',
+        // margin: '32px 0',
       },
     };
   },


### PR DESCRIPTION
Fixes: #181 

## What I did
Remove the styling of `StoryPreview` added from `storybook-readme`

## More Info
I'm not really sure but with the current implementation of `storybook-readme`, user can pass custom components to `addParameter`'s `StoryPreview`. So this default styling of `StoryPreview` is not necessary since user has the full power on styling their `StoryPreview`