### PR TITLE
fix: set default codeTheme in getParameters

### DIFF
--- a/packages/storybook-readme/src/index.js
+++ b/packages/storybook-readme/src/index.js
@@ -34,7 +34,6 @@ export const addReadme = makeDecorator({
   parameterName: 'readme',
   wrapper: (getStory, context) => {
     const parameters = getParameters(context);
-    const codeTheme = parameters.codeTheme || 'github';
     const story = <React.Fragment>{getStory(context)}</React.Fragment>;
     const layout = parameters.layout
       ? parameters.layout
@@ -62,7 +61,7 @@ export const addReadme = makeDecorator({
       channel.emit(CHANNEL_SET_SIDEBAR_DOCS, {
         layout: sidebarLayout,
         theme: parameters.theme,
-        codeTheme: parameters.highlightSidebar ? codeTheme : null,
+        codeTheme: parameters.highlightSidebar ? parameters.codeTheme : null,
       });
     }
 
@@ -70,7 +69,7 @@ export const addReadme = makeDecorator({
       <ReadmeContent
         layout={layout}
         theme={parameters.theme}
-        codeTheme={parameters.highlightContent ? codeTheme : null}
+        codeTheme={parameters.highlightContent ? parameters.codeTheme : null}
         StoryPreview={parameters.StoryPreview}
         HeaderPreview={parameters.HeaderPreview}
         DocPreview={parameters.DocPreview}

--- a/packages/storybook-readme/src/services/getParameters.js
+++ b/packages/storybook-readme/src/services/getParameters.js
@@ -5,7 +5,7 @@ export default function getParameters(context) {
   const config =
     typeof storyOptions === 'string' ? { content: storyOptions } : storyOptions;
 
-  const codeTheme = config.codeTheme;
+  const codeTheme = config.codeTheme || 'github';
 
   return {
     highlightContent: true,


### PR DESCRIPTION
Fixes #186 

## Background
As discussed in #186, some code changes from #173 inadvertently made users who updated this addon lose code highlighting if they didn't explicitly specify a `codeTheme`.

#189  addressed it, but after some testing on my end, I found that it only fixed those that are on the newer 5.x API style. Those who are using `withReadme` (4.x API) will still have this issue.

## Changes
This PR addresses this issue at the root by setting a default `codeTheme` in the `getParameters` file which both API styles reference.
