### PR TITLE
Fix: wrap browser code to function in jest

### DIFF
--- a/packages/storybook-readme/src/backwardCompatibility/index.js
+++ b/packages/storybook-readme/src/backwardCompatibility/index.js
@@ -9,7 +9,15 @@ import * as config from '../services/config';
 
 let handler = null;
 
-switch (window.STORYBOOK_ENV) {
+function getEnvType() {
+  try {
+    return window.STORYBOOK_ENV;
+  } catch (e) {
+    return null;
+  }
+}
+
+switch (getEnvType()) {
   case 'vue':
     handler = vueHandler;
     break;

--- a/packages/storybook-readme/src/styles/styleFactory.js
+++ b/packages/storybook-readme/src/styles/styleFactory.js
@@ -7,6 +7,20 @@ export default function styleFactory(
   let insertedKey = null;
   let node = null;
 
+  function injectStyle(content) {
+    try {
+      node = document.createElement('style');
+
+      node.id = `${name}-${++counter}`;
+      node.innerHTML = content;
+
+      document.head.appendChild(node);
+    } catch (e) {
+      // assume we're not in a browser env, just abort
+      return;
+    }
+  }
+
   return function insert({ theme = {}, styles }) {
     const t = {
       ...defaultTheme,
@@ -23,14 +37,9 @@ export default function styleFactory(
     }
 
     if (!node) {
-      node = document.createElement('style');
-
-      node.id = `${name}-${++counter}`;
-
-      document.head.appendChild(node);
+      injectStyle(styles || getStyles(t));
     }
 
     insertedKey = key;
-    node.innerHTML = styles || getStyles(t);
   };
 }


### PR DESCRIPTION
Closes https://github.com/tuchk4/storybook-readme/issues/192

There are two places that use the browser-specific globals `window` and `document`. This PR wraps both in a try/catch so the plugin will load in non-browser environments like Jest and node.

- Warps check for `window.STORYBOOK_ENV`, returns `null` when not in browser
- Wraps style injection's use of `document`, does nothing when not in browser