### PR TITLE
fix md.replace is not function bug for md.default is the text

### DIFF
--- a/packages/storybook-readme/src/services/getDocsLayout.js
+++ b/packages/storybook-readme/src/services/getDocsLayout.js
@@ -81,6 +81,9 @@ function getStorySource(
 }
 
 function processMd(md) {
+  if (typeof md !== 'string') {
+    md = md.default || ''
+  }
   return marked(transformEmojis(md.replace(MARKER_HIDDEN, '')));
 }
 


### PR DESCRIPTION
fix md.replace is not function bug because md.default is the text