### PR TITLE
Fix parsing default props

### DIFF
--- a/packages/storybook-readme/src/services/getPropsTables/parseProps.js
+++ b/packages/storybook-readme/src/services/getPropsTables/parseProps.js
@@ -9,7 +9,7 @@ const PropTypesMap = new Map();
 //   PropTypesMap.set(type, typeName);
 //   PropTypesMap.set(type.isRequired, typeName);
 // });
-const clearString = str => str.replace(/^\'|\'$/g, '');
+const clearString = str => typeof str === "string" ? str.replace(/^\'|\'$/g, '') : str;
 
 const isNotEmpty = obj => obj && obj.props && Object.keys(obj.props).length > 0;
 

--- a/packages/storybook-readme/src/services/getPropsTables/parseProps.js
+++ b/packages/storybook-readme/src/services/getPropsTables/parseProps.js
@@ -9,7 +9,7 @@ const PropTypesMap = new Map();
 //   PropTypesMap.set(type, typeName);
 //   PropTypesMap.set(type.isRequired, typeName);
 // });
-const clearString = str => typeof str === "string" ? str.replace(/^\'|\'$/g, '') : str;
+const getClearStringForVal = val => `${val || ''}`.replace(/^\'|\'$/g, '');
 
 const isNotEmpty = obj => obj && obj.props && Object.keys(obj.props).length > 0;
 
@@ -36,7 +36,7 @@ const propsFromDocgen = type => {
     switch (propType) {
       case 'enum': {
         // if (typeof docgenInfoProp.type === 'object') {
-        propMeta = docgenInfoProp.type.value.map(v => clearString(v.value));
+        propMeta = docgenInfoProp.type.value.map(v => getClearStringForVal(v.value));
         // }
 
         break;
@@ -85,7 +85,7 @@ const propsFromDocgen = type => {
       propMeta,
       required: docgenInfoProp.required,
       description: docgenInfoProp.description,
-      defaultValue: clearString(defaultValueDesc.value || ''),
+      defaultValue: getClearStringForVal(defaultValueDesc.value),
     };
   });
 

--- a/packages/storybook-readme/src/services/getPropsTables/parseProps.js
+++ b/packages/storybook-readme/src/services/getPropsTables/parseProps.js
@@ -9,7 +9,7 @@ const PropTypesMap = new Map();
 //   PropTypesMap.set(type, typeName);
 //   PropTypesMap.set(type.isRequired, typeName);
 // });
-const getClearStringForVal = val => `${val || ''}`.replace(/^\'|\'$/g, '');
+const getClearStringForVal = val => val ? `${val}`.replace(/^\'|\'$/g, '') : '';
 
 const isNotEmpty = obj => obj && obj.props && Object.keys(obj.props).length > 0;
 


### PR DESCRIPTION
This change addresses a problem I encountered where my component defines defaultProps containing values of type other than string. 

ex:
```
	static defaultProps: TextAreaProps = {
		rows: 5,
		cols: 30,
		name: "Example",
		id: "Another Example",
	};
```
Storybook threw an error from `parseProps.js` because the value of `defaultValueDesc.value` wasn't a string but was passed to `clearString` which invokes `.replace` on the arg. 

I’ve renamed this function to `getClearStringForVal` to better convey the expectation of receiving a “clear” string and to support the existing cases where this function receives values other than strings as arguments.