### PR TITLE
Marked v4.0.10 security update

### DIFF
--- a/packages/storybook-readme/package.json
+++ b/packages/storybook-readme/package.json
@@ -17,7 +17,7 @@
     "html-loader": "^0.5.5",
     "lodash": "^4.17.11",
     "markdown-loader": "^5.0.0",
-    "marked": "^0.7.0",
+    "marked": "^4.0.10",
     "node-emoji": "1.10.0",
     "prism-themes": "^1.1.0",
     "prismjs": "^1.16.0",

--- a/packages/storybook-readme/package.json
+++ b/packages/storybook-readme/package.json
@@ -2,7 +2,7 @@
   "name": "storybook-readme",
   "license": "MIT",
   "private": false,
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "Storybook addon to show components README (for React and Vue)",
   "main": "index.js",
   "homepage": "https://github.com/tuchk4/storybook-readme",

--- a/packages/storybook-readme/src/services/marked.js
+++ b/packages/storybook-readme/src/services/marked.js
@@ -1,3 +1,3 @@
-import marked from 'marked';
+import { marked } from 'marked';
 
 export default md => marked(md);


### PR DESCRIPTION
There is a security vulnerability in versions of marked earlier than 4.0.10. This updates both the version, and the way that the marked function itself is loaded to match the newer requirements since the earlier version (0.7.0).

Details on the security advisory: https://github.com/advisories/GHSA-rrrm-qjm4-v8hf